### PR TITLE
Mask the credit card numbers as soon as possible

### DIFF
--- a/service/AuthorizeDotNet/CimServices.xml
+++ b/service/AuthorizeDotNet/CimServices.xml
@@ -89,6 +89,7 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="expireDateFormatted" value="${expireYear}-${expireMonth}"/>
             <!-- correct masking if needed, use only 'X' -->
             <set field="cardNumber" from="creditCard.cardNumber?.replaceAll(/\D/, 'X')"/>
+            <set field="cardSecurityCode" from="creditCard.cardSecurityCode" />
 
             <!-- clear out creditCard.cardNumber and creditCard.cardSecurityCode -->
             <set field="creditCard.cardSecurityCode" from="null"/>
@@ -114,7 +115,7 @@ along with this software (see the LICENSE.md file). If not, see
             <phoneNumber>${phone ?: ''}</phoneNumber>
         </billTo>
         <payment><creditCard><cardNumber>${cardNumber}</cardNumber><expirationDate>${expireDateFormatted}</expirationDate>
-            ${validateSecurityCode || creditCard.cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: creditCard.cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
+            ${validateSecurityCode || cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
         <customerPaymentProfileId>${paymentMethod.gatewayCimId}</customerPaymentProfileId>
     </paymentProfile>
     <validationMode>${pgan.validationMode}</validationMode>
@@ -137,7 +138,7 @@ along with this software (see the LICENSE.md file). If not, see
             <phoneNumber>${phone ?: ''}</phoneNumber>
         </billTo>
         <payment><creditCard><cardNumber>${cardNumber}</cardNumber><expirationDate>${expireDateFormatted}</expirationDate>
-            ${validateSecurityCode || creditCard.cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: creditCard.cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
+            ${validateSecurityCode || cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
     </paymentProfile>
     <validationMode>${pgan.validationMode}</validationMode>
 </createCustomerPaymentProfileRequest>
@@ -161,7 +162,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <phoneNumber>${phone ?: ''}</phoneNumber>
             </billTo>
             <payment><creditCard><cardNumber>${cardNumber}</cardNumber><expirationDate>${expireDateFormatted}</expirationDate>
-                ${validateSecurityCode || creditCard.cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: creditCard.cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
+                ${validateSecurityCode || cardSecurityCode ? ('<cardCode>' + (validateSecurityCode ?: cardSecurityCode) + '</cardCode>') : ''}</creditCard></payment>
         </paymentProfiles>
      </profile>
     <validationMode>${pgan.validationMode}</validationMode>

--- a/service/AuthorizeDotNet/CimServices.xml
+++ b/service/AuthorizeDotNet/CimServices.xml
@@ -89,6 +89,14 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="expireDateFormatted" value="${expireYear}-${expireMonth}"/>
             <!-- correct masking if needed, use only 'X' -->
             <set field="cardNumber" from="creditCard.cardNumber?.replaceAll(/\D/, 'X')"/>
+
+            <!-- clear out creditCard.cardNumber and creditCard.cardSecurityCode -->
+            <set field="creditCard.cardSecurityCode" from="null"/>
+            <set field="creditCard.cardNumber"
+                    from="'*'.padRight(creditCard.cardNumber.length() - 4, '*') + creditCard.cardNumber.substring(creditCard.cardNumber.length() - 4, creditCard.cardNumber.length())"/>
+            <entity-update value-field="creditCard"/>
+
+
             <if condition="paymentMethod.gatewayCimId"><then>
                 <!-- have a payment profile, call updateCustomerPaymentProfileRequest -->
                 <script><![CDATA[requestString = """<?xml version="1.0" encoding="utf-8"?>
@@ -217,12 +225,6 @@ along with this software (see the LICENSE.md file). If not, see
                 <set field="paymentMethod.paymentGatewayConfigId" from="paymentGatewayConfigId"/>
                 <entity-update value-field="paymentMethod"/>
             </else></if>
-
-            <!-- clear out creditCard.cardNumber and creditCard.cardSecurityCode -->
-            <set field="creditCard.cardSecurityCode" from="null"/>
-            <set field="creditCard.cardNumber"
-                    from="'*'.padRight(creditCard.cardNumber.length() - 4, '*') + creditCard.cardNumber.substring(creditCard.cardNumber.length() - 4, creditCard.cardNumber.length())"/>
-            <entity-update value-field="creditCard"/>
         </actions>
     </service>
 


### PR DESCRIPTION
Today we saw an issue that arose when the vaulting of numbers failed. We were seeing the errors :
`Could not save CIM payment method 114594, message: This transaction has been declined.`

The errors were causing the code to return before the numbers were masked.
```
<return type="danger" message="Could not save CIM payment method ${paymentMethodId}, message: ${reasonMessage}"/>
```

However, many of the numbers that failed to vault were real legitimate numbers, and they remain stored in the DB (encrypted). My solution here is to mask the numbers as soon as possible, before even the fault operation has started. This would reduce the possibility that a failure would occur and the masking not execute. 

I understand that keeping the numbers around might be necessary for troubleshooting, in which case, this PR should be declined. An alternative solution would be to mask all the numbers that failed to vault after a period. If thats a good idea, send me the details and I could have a look. 
 